### PR TITLE
Don't display ... between adjacent numbers

### DIFF
--- a/dist/pagination.js
+++ b/dist/pagination.js
@@ -147,7 +147,7 @@
         },
 
         renderPreviousPages: function renderPreviousPages() {
-            if (this.state.displayedPages.length && this.state.displayedPages[0] > 1) {
+            if (this.state.displayedPages.length && this.state.displayedPages[0] > 2) {
                 return _react2.default.createElement(
                     'li',
                     null,
@@ -163,7 +163,7 @@
         },
 
         renderNextPages: function renderNextPages() {
-            if (this.state.displayedPages.length && this.state.displayedPages[this.state.displayedPages.length - 1] < this.props.pagination.totalPages()) {
+            if (this.state.displayedPages.length && this.state.displayedPages[this.state.displayedPages.length - 1] < this.props.pagination.totalPages() - 1) {
                 return _react2.default.createElement(
                     'li',
                     null,

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -114,7 +114,7 @@ export default React.createClass({
     },
 
     renderPreviousPages: function () {
-        if (this.state.displayedPages.length && this.state.displayedPages[0] > 1) {
+        if (this.state.displayedPages.length && this.state.displayedPages[0] > 2) {
             return (
                 <li>
                     <a href="#" className="show-prev" title="Show previous pages" onClick={this.handleClickShowPrevious}> ... </a>
@@ -126,7 +126,7 @@ export default React.createClass({
     },
 
     renderNextPages: function () {
-        if (this.state.displayedPages.length && this.state.displayedPages[this.state.displayedPages.length - 1] < this.props.pagination.totalPages()) {
+        if (this.state.displayedPages.length && this.state.displayedPages[this.state.displayedPages.length - 1] < this.props.pagination.totalPages() - 1) {
             return (
                 <li>
                     <a href="#" className="show-prev" title="Show next pages" onClick={this.handleClickShowNext}> ... </a>


### PR DESCRIPTION
With a lucky combination of circumstances, we could get
a pagination widget like this:

`1 ... 2 3 4 5 6 ... 20`

That is not ideal; there should be no dots between 1 and 2.

This commit fixes that.
